### PR TITLE
feat(output): save output to disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 *.swp
+build
+

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   registry:
     description: Registry of Image
     required: true
+  output:
+    description: Path to save scan results
+    required: false
 outputs:
   time: # id of output
     description: 'The time we greeted you'
@@ -34,3 +37,5 @@ runs:
     - ${{ inputs.registry }}
     - -image
     - ${{ inputs.image }}
+    - -out
+    - ${{ inputs.output }}


### PR DESCRIPTION
save output to disk if the out flag is passed. this enables us to use
github action artifacts to save the output so that it's easily
capturable from actions instead of having to go into aquasec.